### PR TITLE
Added documentation for deprecated positionQuantizationScale option

### DIFF
--- a/doc/README.options.md
+++ b/doc/README.options.md
@@ -370,7 +370,8 @@ position scaling due to `positionQuantizationScale`.
 
 ### `--positionQuantizationScale=FLOAT-VALUE`
 (Deprecated)
-A scale factor applied to position quantization (range: 0.0 to 1.0) with 1.0 being no quantization. This option is deprecated and may be removed in future versions. 
+A scale factor applied to position quantization (range: 0.0 to 1.0).
+Here lower = more quantized, with 1.0 being no quantization.
 
 ### `--positionQuantisationMethod=0|1|2`
 Selects the method used to determine the QP value for each quantised

--- a/doc/README.options.md
+++ b/doc/README.options.md
@@ -368,6 +368,10 @@ Enables in-loop quantisation and reconstruction of geometry positions.
 NB: All in-loop quantisation is independent (and happens after) any
 position scaling due to `positionQuantizationScale`.
 
+### `--positionQuantizationScale=0|1`
+(Deprecated)
+A scale factor applied to position quantization (range: 0.0 to 1.0) with 1.0 being no quantization. This option is deprecated and may be removed in future versions. 
+
 ### `--positionQuantisationMethod=0|1|2`
 Selects the method used to determine the QP value for each quantised
 tree node.

--- a/doc/README.options.md
+++ b/doc/README.options.md
@@ -368,7 +368,7 @@ Enables in-loop quantisation and reconstruction of geometry positions.
 NB: All in-loop quantisation is independent (and happens after) any
 position scaling due to `positionQuantizationScale`.
 
-### `--positionQuantizationScale=0|1`
+### `--positionQuantizationScale=FLOAT-VALUE`
 (Deprecated) A scale factor applied to position quantization (range: 0.0 to 1.0) with 1.0 being no quantization. This option is deprecated and may be removed in future versions. 
 
 ### `--positionQuantisationMethod=0|1|2`

--- a/doc/README.options.md
+++ b/doc/README.options.md
@@ -369,7 +369,8 @@ NB: All in-loop quantisation is independent (and happens after) any
 position scaling due to `positionQuantizationScale`.
 
 ### `--positionQuantizationScale=FLOAT-VALUE`
-(Deprecated) A scale factor applied to position quantization (range: 0.0 to 1.0) with 1.0 being no quantization. This option is deprecated and may be removed in future versions. 
+(Deprecated)
+A scale factor applied to position quantization (range: 0.0 to 1.0) with 1.0 being no quantization. This option is deprecated and may be removed in future versions. 
 
 ### `--positionQuantisationMethod=0|1|2`
 Selects the method used to determine the QP value for each quantised

--- a/doc/README.options.md
+++ b/doc/README.options.md
@@ -369,8 +369,8 @@ NB: All in-loop quantisation is independent (and happens after) any
 position scaling due to `positionQuantizationScale`.
 
 ### `--positionQuantizationScale=0|1`
-(Deprecated)
-A scale factor applied to position quantization (range: 0.0 to 1.0) with 1.0 being no quantization. This option is deprecated and may be removed in future versions. 
+
+(Deprecated) A scale factor applied to position quantization (range: 0.0 to 1.0) with 1.0 being no quantization. This option is deprecated and may be removed in future versions. 
 
 ### `--positionQuantisationMethod=0|1|2`
 Selects the method used to determine the QP value for each quantised

--- a/doc/README.options.md
+++ b/doc/README.options.md
@@ -369,7 +369,6 @@ NB: All in-loop quantisation is independent (and happens after) any
 position scaling due to `positionQuantizationScale`.
 
 ### `--positionQuantizationScale=0|1`
-
 (Deprecated) A scale factor applied to position quantization (range: 0.0 to 1.0) with 1.0 being no quantization. This option is deprecated and may be removed in future versions. 
 
 ### `--positionQuantisationMethod=0|1|2`

--- a/tmc3/TMC3.cpp
+++ b/tmc3/TMC3.cpp
@@ -720,8 +720,9 @@ ParseParameters(int argc, char* argv[], Parameters& params)
 
   // Alias for compatibility with old name.
   ("positionQuantizationScale", params.encoder.seqGeomScale, 1.,
-   "(Deprecated)"
-    "A scale factor applied to position quantization (range: 0.0 to 1.0) with 1.0 being no quantization.")
+   "(Deprecated) "
+    "A scale factor applied to position quantization (range: 0.0 to 1.0). "
+    "Here lower = more quantized, with 1.0 being no quantization.")
 
   ("externalScale",
     params.encoder.extGeomScale, 1.,

--- a/tmc3/TMC3.cpp
+++ b/tmc3/TMC3.cpp
@@ -720,7 +720,8 @@ ParseParameters(int argc, char* argv[], Parameters& params)
 
   // Alias for compatibility with old name.
   ("positionQuantizationScale", params.encoder.seqGeomScale, 1.,
-   "(deprecated)")
+   "(Deprecated)"
+    "A scale factor applied to position quantization (range: 0.0 to 1.0) with 1.0 being no quantization.")
 
   ("externalScale",
     params.encoder.extGeomScale, 1.,


### PR DESCRIPTION
Adding this here in case anyone else gets confused about existing work using the positionQuantizationScale option since earlier documentation only describes it as "deprecated"